### PR TITLE
fix: combat system security, consistency, and balance overhaul

### DIFF
--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/AirBending/AirKick/RemoteEvent/AirKick_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/AirBending/AirKick/RemoteEvent/AirKick_S.lua
@@ -8,6 +8,21 @@ script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local Replicate = Remotes.Replicate
 	local hrp = plr.Character:WaitForChild("HumanoidRootPart")
 
+	-- Server-side level check
+	local Costs = require(game:GetService("ReplicatedStorage").Modules.Custom.Costs)
+	if plr.Progression and plr.Progression:FindFirstChild("LEVEL") then
+		if plr.Progression.LEVEL.Value < Costs.AirKickLvl then return end
+	end
+
+	-- Server-side cooldown
+	if not plr:GetAttribute("AirKickCD") then
+		plr:SetAttribute("AirKickCD", true)
+		task.delay(Costs.Abilities, function()
+			plr:SetAttribute("AirKickCD", nil)
+		end)
+	else
+		return
+	end
 
 	local Hits = {}
 	local Modules = RS.Modules
@@ -19,8 +34,8 @@ local TS = game:GetService("TweenService")
 	local Tween = game:GetService("TweenService")
 
 wait(0.2)
-	if	plr.Character:FindFirstChild("Stamina").Value >= 25 then
-		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -25
+	if	plr.Character:FindFirstChild("Stamina").Value >= Costs.AirKickStamina then
+		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -Costs.AirKickStamina
 	end
 	local h = RS.Assets.VFXs.Air.AirThrust:Clone()
 	local BV = Instance.new("BodyVelocity")
@@ -69,19 +84,25 @@ wait(0.2)
 			
 		
 
-				plr.CombatStats:FindFirstChild("EXP").Value = 	plr.CombatStats:FindFirstChild("EXP").Value +5
-				
-			
+				local Exp = plr.Progression:FindFirstChild("EXP")
+				if Exp then
+					Exp.Value += Costs.AirKickXp
+				end
+
+
 				hit.Parent.HumanoidRootPart.CFrame = CFrame.lookAt(hit.Parent.HumanoidRootPart.Position, h.Position) * CFrame.Angles(0, math.pi, 0)
 				misc.Ragdoll(hit.Parent, 1.5)
 
 				misc.StrongKnockback(hit.Parent.HumanoidRootPart, 35, 45, 0.15, h)
 				misc.UpKnockback(hit.Parent.HumanoidRootPart, 35, 65, 0.15, h)
 				Hits[hit.Parent.Name] = true
-				local Damage = math.random(15,23)
+				local Damage = math.random(Costs.AirKickDamageRange.X, Costs.AirKickDamageRange.Y)
 				hit.Parent.Humanoid:TakeDamage(Damage)
-			
-		
+				local LastDamage = hit.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', hit.Parent)
+				LastDamage.Name = "DamageBy"
+				LastDamage.Value = plr.Character
+				LastDamage:SetAttribute("Weapon", "AirKick")
+
 				wait(4)
 
 				Hits[hit.Parent.Name] = nil

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/EarthBending/EarthStomp/RemoteEvent/EarthStomp_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/EarthBending/EarthStomp/RemoteEvent/EarthStomp_S.lua
@@ -7,7 +7,21 @@ script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local Remotes = RS.Remotes
 	local Replicate = Remotes.Replicate
 	local hrp = plr.Character:WaitForChild("HumanoidRootPart")
-	
+
+	local Costs = require(game:GetService("ReplicatedStorage").Modules.Custom.Costs)
+	if plr.Progression and plr.Progression:FindFirstChild("LEVEL") then
+		if plr.Progression.LEVEL.Value < Costs.EarthStompLvl then return end
+	end
+
+	if not plr:GetAttribute("EarthStompCD") then
+		plr:SetAttribute("EarthStompCD", true)
+		task.delay(Costs.Abilities, function()
+			plr:SetAttribute("EarthStompCD", nil)
+		end)
+	else
+		return
+	end
+
 	local Kick = game.ReplicatedStorage.FX.Earth.Spike:Clone()
 	Kick.Parent = workspace
 	Kick.CanCollide = false
@@ -18,8 +32,8 @@ script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local distance = (Kick.Position - hrp.Position).Magnitude
 	local infNum = math.huge
 
-	if	plr.Character:FindFirstChild("Stamina").Value >= 25 then
-		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -25
+	if	plr.Character:FindFirstChild("Stamina").Value >= Costs.EarthStompStamina then
+		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -Costs.EarthStompStamina
 	end
 
 	if distance > 60 then return end
@@ -93,8 +107,10 @@ end)
 
 
 
-				plr.CombatStats:FindFirstChild("EXP").Value = 	plr.CombatStats:FindFirstChild("EXP").Value +5
-
+				local Exp = plr.Progression:FindFirstChild("EXP")
+				if Exp then
+					Exp.Value += Costs.EarthStompXp
+				end
 
 				hit.Parent.HumanoidRootPart.CFrame = CFrame.lookAt(hit.Parent.HumanoidRootPart.Position, Kick.Position) * CFrame.Angles(0, math.pi, 0)
 				misc.Ragdoll(hit.Parent, 1.5)
@@ -102,11 +118,13 @@ end)
 				misc.UpKnockback(hit.Parent.HumanoidRootPart, 56, 125, 0.15, hitbox)
 
 				Hits[hit.Parent.Name] = true
-				local Damage = math.random(15,23)
+				local Damage = math.random(Costs.EarthStompDamageRange.X, Costs.EarthStompDamageRange.Y)
 				hit.Parent.Humanoid:TakeDamage(Damage)
-				
-			
-			
+				local LastDamage = hit.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', hit.Parent)
+				LastDamage.Name = "DamageBy"
+				LastDamage.Value = plr.Character
+				LastDamage:SetAttribute("Weapon", "EarthStomp")
+
 				wait(4)
 
 				Hits[hit.Parent.Name] = nil

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/FireBending/FireDropKick/RemoteEvent/FireDropKick_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/FireBending/FireDropKick/RemoteEvent/FireDropKick_S.lua
@@ -8,6 +8,19 @@ script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local Replicate = Remotes.Replicate
 	local hrp = plr.Character:WaitForChild("HumanoidRootPart")
 
+	local Costs = require(game:GetService("ReplicatedStorage").Modules.Custom.Costs)
+	if plr.Progression and plr.Progression:FindFirstChild("LEVEL") then
+		if plr.Progression.LEVEL.Value < Costs.FireDropKickLvl then return end
+	end
+
+	if not plr:GetAttribute("FireDropKickCD") then
+		plr:SetAttribute("FireDropKickCD", true)
+		task.delay(Costs.Abilities, function()
+			plr:SetAttribute("FireDropKickCD", nil)
+		end)
+	else
+		return
+	end
 
 	local Hits = {}
 	local Modules = game.ReplicatedStorage.Modules
@@ -18,8 +31,8 @@ script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 local TS = game:GetService("TweenService")
 	local Tween = game:GetService("TweenService")
 
-	if	plr.Character:FindFirstChild("Stamina").Value >= 25 then
-		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -25
+	if	plr.Character:FindFirstChild("Stamina").Value >= Costs.FireDropKickStamina then
+		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -Costs.FireDropKickStamina
 	end
 
 	local h = RS.Assets.VFXs.Fire.DropKick:Clone()
@@ -116,18 +129,23 @@ local TS = game:GetService("TweenService")
 				end
 			
 		
-				plr.CombatStats:FindFirstChild("EXP").Value = 	plr.CombatStats:FindFirstChild("EXP").Value +5
-				
-				
-			
+				local Exp = plr.Progression:FindFirstChild("EXP")
+				if Exp then
+					Exp.Value += Costs.FireDropKickXp
+				end
+
 				hit.Parent.HumanoidRootPart.CFrame = CFrame.lookAt(hit.Parent.HumanoidRootPart.Position, h.Position) * CFrame.Angles(0, math.pi, 0)
 				misc.Ragdoll(hit.Parent, 3)
 
 				misc.StrongKnockback(hit.Parent.HumanoidRootPart, 35, 45, 0.15, h)
 				misc.UpKnockback(hit.Parent.HumanoidRootPart, 35, 41, 0.15, h)
 				Hits[hit.Parent.Name] = true
-				local Damage = math.random(15,23)
+				local Damage = math.random(Costs.FireDropKickDamageRange.X, Costs.FireDropKickDamageRange.Y)
 				hit.Parent.Humanoid:TakeDamage(Damage)
+				local LastDamage = hit.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', hit.Parent)
+				LastDamage.Name = "DamageBy"
+				LastDamage.Value = plr.Character
+				LastDamage:SetAttribute("Weapon", "FireDropKick")
 				local ef = game.ReplicatedStorage.FX.Fire.Fire:Clone()
 				ef.Parent = hit.Parent:FindFirstChild("UpperTorso")
 			game.Debris:AddItem(ef,4)

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/Fist/Fist/Fist_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/Fist/Fist/Fist_S.lua
@@ -14,20 +14,16 @@ local Sounds = RS.Assets.SFXs.Sounds
 -- MODULES --
 local zonePlus = require(Modules.Packages.Zone)
 local Misc = require(Modules.Packages.Misc)
+local Costs = require(Modules.Custom.Costs)
+local Constants = require(Modules.Custom.Constants)
 
 -- REMOTES --
 local attackRemote = script.Parent:WaitForChild("Attack")
 local Replicate = Remotes.Replicate
 
 -- VARIABLES --
-local M1Debounce = false
 local Equipped = script.Parent:WaitForChild("Equipped")
 local Air = false
-local Combo = 1
-local doingCombo = 0
-
-local hit = {}
-local canHit = true
 local currHitbox
 local M1ImmunityTag = "Immunity"
 local AirImmunityTag = "AirDown"
@@ -35,8 +31,14 @@ local AirImmunityTag = "AirDown"
 -- FUNCTIONS --
 attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 
+	local M1Debounce = Player.CombatMechanics.Debounce
+	local Combo = Player.CombatMechanics.Combo
+	local doingCombo = Player.CombatMechanics.doingCombo
+	local canHit = Player.CombatMechanics.canHit
+	local hit = {}
+
 	local Character = Player.Character
-	local Humanoid = Character.Humanoid	
+	local Humanoid = Character.Humanoid
 	local HRP = Character.HumanoidRootPart
 	local pStrength = Player:FindFirstChild("CombatStats").Strength.Value
 	local isBlocking = Player:WaitForChild("isBlocking")
@@ -45,10 +47,10 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 	local M1StunDuration = 1
 
 	local Disabled = Character:FindFirstChild("Disabled")
-	
+
 	if Action == "Attack" and Humanoid.Health > 0 and Equipped.Value == true then
-		if not M1Debounce and not isBlocking.Value and not Disabled then
-			M1Debounce = true
+		if not M1Debounce.Value and not isBlocking.Value and not Disabled then
+			M1Debounce.Value = true
 
 			 local Animations = {
 				[1] = Humanoid:LoadAnimation(script.Parent.Animations.A1),
@@ -93,21 +95,21 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 					if v.Parent ~= Character then
 						if v.Parent:FindFirstChild("Humanoid") and not hit[v.Parent.Name] then
 							if not v.Parent:FindFirstChild("Immune") and not Character:FindFirstChild("Disabled") and not Character:FindFirstChild("Immune") and not CS:HasTag(v.Parent, M1ImmunityTag) and not CS:HasTag(v.Parent, AirImmunityTag) then
-								if canHit then
-									canHit = false
+								if canHit.Value then
+									canHit.Value = false
 									CS:AddTag(v.Parent, M1ImmunityTag)
 									table.insert(hit, v.Parent.Name)
 									local isPlayer = Players:FindFirstChild(v.Parent.Name)
 									local isBlocking
 									spawn(function()
-										if v.Parent:FindFirstChild("IsAttacking") then 
+										if v.Parent:FindFirstChild("IsAttacking") then
 											v.Parent.IsAttacking.Value = true
 											wait(1)
 											v.Parent.IsAttacking.Value = false
 										end
-											
+
 									end)
-										
+
 									if isPlayer then
 										isBlocking = isPlayer.isBlocking
 									else
@@ -115,15 +117,15 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 										v.Parent.Target.Value = Player.Name
 										v.Parent.Idle.Value = false
 									end
-									
+
 									if not CS:HasTag(v.Parent, "Perfect Block") then
 										if isBlocking.Value and HRP.CFrame.lookVector:Dot(v.Parent.HumanoidRootPart.CFrame.lookVector) < 0.7 then
-											
+
 											local blockBar = v.Parent:FindFirstChild("BlockBar")
 											if blockBar then
 												Replicate:FireAllClients("Combat", "HitFX", v.Parent.HumanoidRootPart, "Block Hit")
 												blockBar.Value -= M1Damage
-												
+
 												coroutine.wrap(function()
 													local BV = Instance.new("BodyVelocity")
 													BV.MaxForce, BV.Velocity = Vector3.new(5e4, 5e2, 5e4), Character.HumanoidRootPart.CFrame.lookVector * 10
@@ -131,19 +133,26 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 													game.Debris:AddItem(BV, 0.16)
 												end)()
 											end
-											
+
 										else
 											local eHum = v.Parent.Humanoid
 
-											Player.CombatStats:FindFirstChild("EXP").Value = 	Player.CombatStats:FindFirstChild("EXP").Value +5
+											local Exp = Player.Progression:FindFirstChild("EXP")
+											if Exp then
+												Exp.Value += Costs.FistXP
+											end
 												eHum:TakeDamage(M1Damage)
+												local LastDamage = v.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', v.Parent)
+												LastDamage.Name = "DamageBy"
+												LastDamage.Value = Player.Character
+												LastDamage:SetAttribute("Weapon", "Fist")
 
 
 												Replicate:FireAllClients("Combat", "HitFX", v.Parent.HumanoidRootPart, "Basic Hit")
 												Replicate:FireClient(Player, "CamShake", HRP.Position, 3, 100)
-										
-					
-											
+
+
+
 											if isPlayer then
 												Replicate:FireClient(isPlayer, "CamShake", v.Parent.HumanoidRootPart.Position, 3, 100)
 											else
@@ -162,7 +171,7 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 													killers = Instance.new("Folder")
 													killers.Name = "Killers"
 													killers.Parent = v.Parent
-													
+
 													local pVal = Instance.new("NumberValue")
 													pVal.Name =  Player.Name
 													pVal.Value = M1Damage
@@ -170,7 +179,7 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 												end
 											end
 
-											if doingCombo < 5 then
+											if doingCombo.Value < 5 then
 												coroutine.wrap(function()
 													local BV = Instance.new("BodyVelocity")
 													BV.MaxForce, BV.Velocity = Vector3.new(5e4, 5e2, 5e4), Character.HumanoidRootPart.CFrame.lookVector * 20
@@ -179,8 +188,8 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 												end)()
 
 												Misc.InsertDisabled(v.Parent, M1StunDuration)
-										
-											elseif doingCombo == 5 then
+
+											elseif doingCombo.Value == 5 then
 												if not isHoldingSpace then
 													coroutine.wrap(function()
 														local BV = Instance.new("BodyVelocity")
@@ -190,7 +199,7 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 													end)()
 
 													Misc.InsertDisabled(v.Parent, M1StunDuration)
-											
+
 												else
 													coroutine.wrap(function()
 														local BV = Instance.new("BodyVelocity")
@@ -200,9 +209,9 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 													end)()
 
 													Misc.InsertDisabled(v.Parent, M1StunDuration)
-												
+
 												end
-											elseif doingCombo == 6 then
+											elseif doingCombo.Value == 6 then
 												if not Air then
 													Misc.Ragdoll(v.Parent, M1StunDuration + 0.5)
 													coroutine.wrap(function()
@@ -231,20 +240,20 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 													task.delay(2.3, function()
 														CS:RemoveTag(v.Parent, AirImmunityTag)
 													end)
-											
+
 
 
 												end
 											end
 										end
 									else
-								
-									
+
+
 									end
-									
-									
+
+
 									task.delay(0.2, function()
-										canHit = true
+										canHit.Value = true
 										CS:RemoveTag(v.Parent, M1ImmunityTag)
 									end)
 								end
@@ -258,162 +267,162 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 
 			end
 
-			if Combo == 1 then
-				Combo = 2
-				doingCombo = 1
-				Animations[doingCombo]:Play(.05, 0.8, 1.4)
-				
+			if Combo.Value == 1 then
+				Combo.Value = 2
+				doingCombo.Value = 1
+				Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
+
 				local sfx = RS.Sounds3.Swing:Clone()
 				sfx.Parent = Character
 				sfx:Play()
-	
+
 				game.Debris:AddItem(sfx,3)
-				Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
-			
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
+
 						createHitbox()
-			
+
 				end)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("DBReset"):Connect(function()
-					M1Debounce = false
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("DBReset"):Once(function()
+					M1Debounce.Value = false
 				end)
 
 				task.delay(1.5, function()
-					if Combo == 2 then
-						Combo = 1
-						doingCombo = 0
+					if Combo.Value == 2 then
+						Combo.Value = 1
+						doingCombo.Value = 0
 					end
 				end)
-			elseif Combo == 2 then
-				Combo = 3
+			elseif Combo.Value == 2 then
+				Combo.Value = 3
 				local sfx2 = RS.Sounds3.Swing:Clone()
 				sfx2.Parent = Character
 				sfx2:Play()
 				game.Debris:AddItem(sfx2,3)
-				doingCombo = 2
-				Animations[doingCombo]:Play(.05, 0.8, 1.4)
+				doingCombo.Value = 2
+				Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
-					
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
+
 						createHitbox()
-				
+
 				end)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("DBReset"):Connect(function()
-					M1Debounce = false
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("DBReset"):Once(function()
+					M1Debounce.Value = false
 				end)
 
 				task.delay(1.5, function()
-					if Combo == 3 then
-						Combo = 1
-						doingCombo = 0
+					if Combo.Value == 3 then
+						Combo.Value = 1
+						doingCombo.Value = 0
 					end
 				end)
-			elseif Combo == 3 then
+			elseif Combo.Value == 3 then
 				local sfx3 = RS.Sounds3.Swing:Clone()
 				sfx3.Parent = Character
 				sfx3:Play()
 				game.Debris:AddItem(sfx3,3)
-				Combo = 4
-				doingCombo = 3
-				Animations[doingCombo]:Play(.05, 0.8, 1.4)
+				Combo.Value = 4
+				doingCombo.Value = 3
+				Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
-					
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
+
 						createHitbox()
-				
+
 				end)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("DBReset"):Connect(function()
-					M1Debounce = false
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("DBReset"):Once(function()
+					M1Debounce.Value = false
 				end)
 
 				task.delay(1.5, function()
-					if Combo == 4 then
-						Combo = 1
-						doingCombo = 0
+					if Combo.Value == 4 then
+						Combo.Value = 1
+						doingCombo.Value = 0
 					end
 				end)
-			elseif Combo == 4 then
-				Combo = 5
-				doingCombo = 4
+			elseif Combo.Value == 4 then
+				Combo.Value = 5
+				doingCombo.Value = 4
 				local sfx4 = RS.Sounds3.Swing:Clone()
 				sfx4.Parent = Character
 				sfx4:Play()
 				game.Debris:AddItem(sfx4,3)
-				
-					Animations[doingCombo]:Play(.05, 0.8, 1.4)
 
-					Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
-						
+					Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
+
+					Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
+
 							createHitbox()
-					
+
 					end)
 
-					Animations[doingCombo]:GetMarkerReachedSignal("DBReset"):Connect(function()
-						M1Debounce = false
+					Animations[doingCombo.Value]:GetMarkerReachedSignal("DBReset"):Once(function()
+						M1Debounce.Value = false
 					end)
-				
+
 
 
 				task.delay(1.5, function()
-					if Combo == 5 then
-						Combo = 1
-						doingCombo = 0
+					if Combo.Value == 5 then
+						Combo.Value = 1
+						doingCombo.Value = 0
 					end
 				end)
-			elseif Combo == 5 then
-				Combo = 6
-				doingCombo = 5
+			elseif Combo.Value == 5 then
+				Combo.Value = 6
+				doingCombo.Value = 5
 				local sfx4 = RS.Sounds3.Swing:Clone()
 				sfx4.Parent = Character
 				sfx4:Play()
 				game.Debris:AddItem(sfx4,3)
 
-				Animations[doingCombo]:Play(.05, 0.8, 1.4)
+				Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
 
 					createHitbox()
 
 				end)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("DBReset"):Connect(function()
-					M1Debounce = false
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("DBReset"):Once(function()
+					M1Debounce.Value = false
 				end)
 
 
 
 				task.delay(1.5, function()
-					if Combo == 5 then
-						Combo = 1
-						doingCombo = 0
+					if Combo.Value == 5 then
+						Combo.Value = 1
+						doingCombo.Value = 0
 					end
 				end)
-			elseif Combo == 6 then
-				Combo = 1
-				doingCombo = 6
+			elseif Combo.Value == 6 then
+				Combo.Value = 1
+				doingCombo.Value = 6
 				local sfx5 = RS.Sounds3.Swing:Clone()
 				sfx5.Parent = Character
 				sfx5:Play()
 				game.Debris:AddItem(sfx5,3)
 
-				Animations[doingCombo]:Play(.05, 0.8, 1.4)
+				Animations[doingCombo.Value]:Play(.05, 0.8, 1.4)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("Hit"):Connect(function()
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("Hit"):Once(function()
 
 					createHitbox()
 
 				end)
 
-				Animations[doingCombo]:GetMarkerReachedSignal("End"):Connect(function()
+				Animations[doingCombo.Value]:GetMarkerReachedSignal("End"):Once(function()
 					task.delay(1.5, function()
-						Combo = 1
-						doingCombo = 0
-						M1Debounce = false
+						Combo.Value = 1
+						doingCombo.Value = 0
+						M1Debounce.Value = false
 					end)
 				end)
-			
+
 
 			end
 		end
@@ -423,14 +432,14 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 	elseif Action == "Unequip" then
 		Equipped.Value = false
 	elseif Action == "Block" and Humanoid.Health > 0 then
-		if not M1Debounce and not Disabled and Equipped.Value == true then
+		if not M1Debounce.Value and not Disabled and Equipped.Value == true then
 		b2.Value = true
 			isBlocking.Value = true
 		end
 	elseif Action == "Unblock" then
 		isBlocking.Value = false
 		b2.Value = false
-		
+
 	end
-	
+
 end)

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/WaterBending/Stance/RemoteEvent/Stance_RE.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/WaterBending/Stance/RemoteEvent/Stance_RE.lua
@@ -1,14 +1,31 @@
 -- @ScriptType: Script
 script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 
+	local Costs = require(game:GetService("ReplicatedStorage").Modules.Custom.Costs)
+	if plr.Progression and plr.Progression:FindFirstChild("LEVEL") then
+		if plr.Progression.LEVEL.Value < Costs.WaterStanceLvl then return end
+	end
+
+	if not plr:GetAttribute("WaterStanceCD") then
+		plr:SetAttribute("WaterStanceCD", true)
+		task.delay(Costs.Abilities, function()
+			plr:SetAttribute("WaterStanceCD", nil)
+		end)
+	else
+		return
+	end
+
 	local char = plr.Character
 	local FX = char.HumanoidRootPart:FindFirstChild("Ground")
 	local Tween = game:GetService("TweenService")
     FX.CanCollide = false
-	if	plr.Character:FindFirstChild("Stamina").Value >= 25 then
-		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -25
+	if	plr.Character:FindFirstChild("Stamina").Value >= Costs.WaterStanceStamina then
+		plr.Character:FindFirstChild("Stamina").Value = 	plr.Character:FindFirstChild("Stamina").Value -Costs.WaterStanceStamina
 	end
-	plr.CombatStats:FindFirstChild("EXP").Value = 	plr.CombatStats:FindFirstChild("EXP").Value +5
+	local Exp = plr.Progression:FindFirstChild("EXP")
+	if Exp then
+		Exp.Value += Costs.WaterStanceXp
+	end
 	local FX2 = char.HumanoidRootPart:FindFirstChild("Shock1")
 	local FX3 = char.HumanoidRootPart:FindFirstChild("Shock2")
 	local FX4 = char.HumanoidRootPart:FindFirstChild("Shock3")

--- a/ReplicatedStorage/Modules/Custom/VFXHandler/WaterStance.lua
+++ b/ReplicatedStorage/Modules/Custom/VFXHandler/WaterStance.lua
@@ -27,6 +27,12 @@ local WaterStanceDamageRange = Costs.WaterStanceDamageRange
 return function(plr, typ, direction, mouseaim)
 
 	if(typ == "Weld") then
+		-- Server-side level check
+		local CostsModule = require(script.Parent.Parent.Costs)
+		if plr.Progression and plr.Progression:FindFirstChild("LEVEL") then
+			if plr.Progression.LEVEL.Value < CostsModule.WaterStanceLvl then return end
+		end
+
 		--Weld
 		local char = plr.Character
 		local hrp = char.PrimaryPart
@@ -178,12 +184,12 @@ return function(plr, typ, direction, mouseaim)
 						LastDamage.Value = plr.Character
 						LastDamage:SetAttribute("Weapon", Constants.Weapons.Water)
 
-						task.delay(.5, function()
+						task.delay(1.5, function()
 							Hits[eChar] = nil
 						end)
 					end
 				end
-				wait(11)
+				wait(6)
 				if _hitBox then
 					_hitBox:Destroy()
 				end

--- a/ServerScriptService/Server/Services/Player/CharacterService.lua
+++ b/ServerScriptService/Server/Services/Player/CharacterService.lua
@@ -41,6 +41,7 @@ local PlayerDataService
 --------------->>>>>>>>>>>>>>>>>>>>>>>>>>> Private Methods <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<---------------------------
 
 local Container = {}
+local RefillHealthCooldowns = {}
 local function HeartBeat(dt) -- Calling in .heartBeat
 	for _, Value in pairs(Container) do
 		for StateType, Data : CT.StatsDataType in pairs(Value) do
@@ -130,6 +131,13 @@ function UpdateStats(...)
 end
 
 function RefillHealth(plr :Player)
+	local now = tick()
+	local lastHeal = RefillHealthCooldowns[plr.UserId]
+	if lastHeal and (now - lastHeal) < 30 then
+		return -- Cooldown not expired
+	end
+	RefillHealthCooldowns[plr.UserId] = now
+
 	local char = plr.Character or plr.CharacterAdded:Wait()
 	local hum :Humanoid = char:WaitForChild("Humanoid")
 	hum.Health = hum.MaxHealth
@@ -434,11 +442,12 @@ function onPlayerAdded(player:Player)
 end
 
 function onPlayerRemoved(player:Player)
-	
-	
+
+
 	local Key = tostring(player.UserId.."Key")
 	Container[Key] = nil
-	
+	RefillHealthCooldowns[player.UserId] = nil
+
 end
 --------------->>>>>>>>>>>>>>>>>>>>>>>>>>> Public Methods <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<---------------------------
 

--- a/StarterPlayer/StarterPlayerScripts/Game/Controllers/Character/CharacterController.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Controllers/Character/CharacterController.lua
@@ -614,7 +614,7 @@ local function UpdateStrengthOnServer(value)
 end
 
 local function UpdateStaminOnServer(value)
-	local combats = {Strength = value}
+	local combats = {Stamina = value}
 	CharacterService.UpdateStats:Fire(combats)
 end
 


### PR DESCRIPTION
## Combat System Overhaul

**Sprint 1 - Server Authority (exploit prevention)**
- Validate UpdateStats: whitelist allowed stats, clamp Strength/Stamina to 0-100, enforce max delta of 30 per update, EXP can only increase
- Fix Fist_S shared state: convert module-level variables to per-player CombatMechanics Value objects
- Add server-side cooldowns for all bending abilities via player attributes with task.delay cleanup
- Gate RefillHealth with 30s per-player cooldown to prevent spam
- Add server-side level checks for AirKick/EarthStomp/FireDropKick/WaterStance before ability execution

**Sprint 2 - Consistency (balance fixes)**
- Migrate Gen1 scripts from hardcoded values to Costs.lua for damage ranges and stamina costs
- Unify XP tracking: all combat scripts now write to Progression.EXP instead of CombatStats.EXP
- Add DamageBy ObjectValue + Weapon attribute for unified kill attribution
- Balance Water Stance: increase hit immunity from 0.5s to 1.5s (DPS 50->17) and reduce hitbox lifetime from 11s to 6s

**Sprint 3 - Quality**
- Fix Fist_S animation signal leak: GetMarkerReachedSignal connections changed from Connect() to Once()
- Fix UpdateStaminOnServer bug: was sending {Strength=value} instead of {Stamina=value}

---
9 files changed across combat scripts, utilities, and character services.