### PR TITLE
Sprint 1: First-Session Survival - SafeZone PvP Protection + Tutorial Fix

### DIFF
--- a/ReplicatedStorage/Modules/Custom/Costs.lua
+++ b/ReplicatedStorage/Modules/Custom/Costs.lua
@@ -58,4 +58,7 @@ return {
 	--
 	BoomerangDamageRange = Vector2.new(30, 50),
 	MeteoriteSwordDamageRange = Vector2.new(15, 25),
+
+	--> Spawn Protection (Sprint 1)
+	SpawnProtectionDuration = 8, -- seconds of ForceField after spawning
 }

--- a/ReplicatedStorage/Modules/Packages/DamageModule.lua
+++ b/ReplicatedStorage/Modules/Packages/DamageModule.lua
@@ -2,6 +2,7 @@
 local RS = game:GetService("ReplicatedStorage")
 local FXFolder = RS:WaitForChild("FX")
 local CS = game:GetService("CollectionService")
+local Players = game:GetService("Players")
 
 local Modules = RS:WaitForChild("Modules")
 local Remotes = RS:WaitForChild("Remotes")
@@ -11,11 +12,43 @@ local Misc = require(Modules:WaitForChild("Misc"))
 
 local module = {}
 
+-- FIX: Block PvP damage in safe zones (Sprint 1)
+local function isPvPBlocked(attackerPlayer: Player, targetHumanoid: Humanoid): boolean
+	local targetChar = targetHumanoid.Parent
+	if not targetChar then return false end
+
+	-- Allow PvE always
+	local targetPlayer = Players:GetPlayerFromCharacter(targetChar)
+	if not targetPlayer then
+		return false -- NPC target
+	end
+
+	-- Block if either player is in safe zone
+	if attackerPlayer:GetAttribute("InSafeZone") then
+		return true
+	end
+	if targetPlayer:GetAttribute("InSafeZone") then
+		return true
+	end
+
+	-- Block if target has spawn protection ForceField
+	if targetChar:FindFirstChildOfClass("ForceField") then
+		return true
+	end
+
+	return false
+end
+
 module.OnHit = function(player, humanoid, Damage, isBlockBreak)
 	if not player then return end
 	local char = player.Character
 	if not char then return end
 	if char:FindFirstChild("ForceField") then return end
+
+	-- FIX: Check SafeZone PvP protection
+	if isPvPBlocked(player, humanoid) then
+		return
+	end
 	
 		--and not char:FindFirstChild("Disabled")
 	if humanoid and not humanoid.Parent:FindFirstChild("Immune") and not CS:HasTag(humanoid.Parent, "PerfectBlock") then
@@ -79,87 +112,87 @@ module.OnHit = function(player, humanoid, Damage, isBlockBreak)
 								lPlrDMG.Parent = KillersFolder
 							end
 						end
-					end
-				else
-					local blockbar = humanoid.Parent:FindFirstChild("BlockBar")
-					if blockbar then
-						if not isBlockBreak then
-							blockbar.Value -= (Damage * 0.5)
-						else
-							blockbar.Value = 0
+					else
+						local blockbar = humanoid.Parent:FindFirstChild("BlockBar")
+						if blockbar then
+							if not isBlockBreak then
+								blockbar.Value -= (Damage * 0.5)
+							else
+								blockbar.Value = 0
 
-							humanoid:TakeDamage(Damage)
-							Replicate:FireAllClients("DamageIndicator", humanoid.Parent, Damage, "Normal")
+								humanoid:TakeDamage(Damage)
+								Replicate:FireAllClients("DamageIndicator", humanoid.Parent, Damage, "Normal")
 
-							local isIdle = humanoid.Parent:FindFirstChild("Idle")
-							if isIdle then
-								if isIdle.Value then
-									isIdle.Value = false
+								local isIdle = humanoid.Parent:FindFirstChild("Idle")
+								if isIdle then
+									if isIdle.Value then
+										isIdle.Value = false
+									end
 								end
-							end
 
-							local Killers = humanoid.Parent:FindFirstChild("Killers")
-							if Killers then
-								local lPlr = Killers:FindFirstChild(player.Name)
-								if not lPlr then
+								local Killers = humanoid.Parent:FindFirstChild("Killers")
+								if Killers then
+									local lPlr = Killers:FindFirstChild(player.Name)
+									if not lPlr then
+										local lPlrDMG = Instance.new("NumberValue")
+										lPlrDMG.Name = player.Name
+										lPlrDMG.Value = Damage
+										lPlrDMG.Parent = Killers
+									else
+										lPlr.Value += Damage
+									end
+								else
+									local KillersFolder = Instance.new("Folder")
+									KillersFolder.Name = "Killers"
+									KillersFolder.Parent = humanoid.Parent
+
 									local lPlrDMG = Instance.new("NumberValue")
 									lPlrDMG.Name = player.Name
 									lPlrDMG.Value = Damage
-									lPlrDMG.Parent = Killers
-								else
-									lPlr.Value += Damage
+									lPlrDMG.Parent = KillersFolder
 								end
-							else
-								local KillersFolder = Instance.new("Folder")
-								KillersFolder.Name = "Killers"
-								KillersFolder.Parent = humanoid.Parent
-
-								local lPlrDMG = Instance.new("NumberValue")
-								lPlrDMG.Name = player.Name
-								lPlrDMG.Value = Damage
-								lPlrDMG.Parent = KillersFolder
 							end
 						end
 					end
-				end
 
-				local isIdle = humanoid.Parent:FindFirstChild("Idle")
-				if isIdle then
-					if isIdle.Value then
-						isIdle.Value = false
+					local isIdle = humanoid.Parent:FindFirstChild("Idle")
+					if isIdle then
+						if isIdle.Value then
+							isIdle.Value = false
+						end
 					end
-				end
-			else
-				humanoid:TakeDamage(Damage)
-				Replicate:FireAllClients("DamageIndicator", humanoid.Parent, Damage, "Normal")
+				else
+					humanoid:TakeDamage(Damage)
+					Replicate:FireAllClients("DamageIndicator", humanoid.Parent, Damage, "Normal")
 
-				local isIdle = humanoid.Parent:FindFirstChild("Idle")
-				if isIdle then
-					if isIdle.Value then
-						isIdle.Value = false
+					local isIdle = humanoid.Parent:FindFirstChild("Idle")
+					if isIdle then
+						if isIdle.Value then
+							isIdle.Value = false
+						end
 					end
-				end
 
-				local Killers = humanoid.Parent:FindFirstChild("Killers")
-				if Killers then
-					local lPlr = Killers:FindFirstChild(player.Name)
-					if not lPlr then
+					local Killers = humanoid.Parent:FindFirstChild("Killers")
+					if Killers then
+						local lPlr = Killers:FindFirstChild(player.Name)
+						if not lPlr then
+							local lPlrDMG = Instance.new("NumberValue")
+							lPlrDMG.Name = player.Name
+							lPlrDMG.Value = Damage
+							lPlrDMG.Parent = Killers
+						else
+							lPlr.Value += Damage
+						end
+					else
+						local KillersFolder = Instance.new("Folder")
+						KillersFolder.Name = "Killers"
+						KillersFolder.Parent = humanoid.Parent
+
 						local lPlrDMG = Instance.new("NumberValue")
 						lPlrDMG.Name = player.Name
 						lPlrDMG.Value = Damage
-						lPlrDMG.Parent = Killers
-					else
-						lPlr.Value += Damage
+						lPlrDMG.Parent = KillersFolder
 					end
-				else
-					local KillersFolder = Instance.new("Folder")
-					KillersFolder.Name = "Killers"
-					KillersFolder.Parent = humanoid.Parent
-
-					local lPlrDMG = Instance.new("NumberValue")
-					lPlrDMG.Name = player.Name
-					lPlrDMG.Value = Damage
-					lPlrDMG.Parent = KillersFolder
 				end
 			end
 		end

--- a/ServerScriptService/Server/Services/Player/SpawnProtectionService.lua
+++ b/ServerScriptService/Server/Services/Player/SpawnProtectionService.lua
@@ -1,0 +1,193 @@
+-- @ScriptType: ModuleScript
+-- SpawnProtectionService: Gives newly spawned players temporary invulnerability
+-- and marks players inside designated SafeZone parts.
+--
+-- SETUP REQUIRED IN ROBLOX STUDIO:
+-- 1. Create Part(s) in workspace named "SafeZone" (or tagged "SafeZone" via CollectionService)
+-- 2. Set CanCollide = false, Transparency = 1, Anchored = true
+-- 3. Size the part to cover the spawn/hub area
+-- 4. The service will detect players inside these parts and set a "SafeZone" attribute
+
+local Players = game:GetService("Players")
+local RS = game:GetService("ReplicatedStorage")
+local CS = game:GetService("CollectionService")
+local RunService = game:GetService("RunService")
+
+local Knit = require(RS.Packages.Knit)
+local Costs = require(RS.Modules.Custom.Costs)
+
+local SpawnProtectionService = Knit.CreateService {
+	Name = "SpawnProtectionService",
+	Client = {},
+}
+
+-- Configuration (from Costs.lua)
+local FORCEFIELD_DURATION: number = Costs.SpawnProtectionDuration or 8
+local SAFE_ZONE_CHECK_INTERVAL: number = 1
+
+-- Track active safe zone parts
+local safeZoneParts: {BasePart} = {}
+
+----- Private Methods -----
+
+local function giveForceField(character: Model)
+	-- Remove existing ForceField if any
+	local existing = character:FindFirstChildOfClass("ForceField")
+	if existing then
+		existing:Destroy()
+	end
+
+	local ff = Instance.new("ForceField")
+	ff.Name = "SpawnProtection"
+	ff.Visible = true
+	ff.Parent = character
+
+	-- Remove after duration
+	task.delay(FORCEFIELD_DURATION, function()
+		if ff and ff.Parent then
+			ff:Destroy()
+		end
+	end)
+end
+
+local function isInsideSafeZone(position: Vector3): boolean
+	for _, part in ipairs(safeZoneParts) do
+		if part and part.Parent then
+			-- Check if position is inside the part's bounding box
+			local relativePos = part.CFrame:PointToObjectSpace(position)
+			local halfSize = part.Size / 2
+			if math.abs(relativePos.X) <= halfSize.X
+				and math.abs(relativePos.Y) <= halfSize.Y
+				and math.abs(relativePos.Z) <= halfSize.Z then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+local function updateSafeZoneStatus()
+	for _, plr in ipairs(Players:GetPlayers()) do
+		local char = plr.Character
+		if char then
+			local root = char:FindFirstChild("HumanoidRootPart")
+			if root then
+				local inZone = isInsideSafeZone(root.Position)
+				-- Set attribute on both player and character for easy checking
+				plr:SetAttribute("InSafeZone", inZone)
+				char:SetAttribute("InSafeZone", inZone)
+			end
+		end
+	end
+end
+
+local function collectSafeZoneParts()
+	safeZoneParts = {}
+
+	-- Collect by tag
+	for _, part in ipairs(CS:GetTagged("SafeZone")) do
+		if part:IsA("BasePart") then
+			table.insert(safeZoneParts, part)
+		end
+	end
+
+	-- Also collect by name in workspace
+	for _, obj in ipairs(workspace:GetDescendants()) do
+		if obj:IsA("BasePart") and obj.Name == "SafeZone" and not CS:HasTag(obj, "SafeZone") then
+			CS:AddTag(obj, "SafeZone")
+			table.insert(safeZoneParts, obj)
+		end
+	end
+
+	print("[SpawnProtection] Found", #safeZoneParts, "safe zone parts")
+end
+
+local function onCharacterAdded(player: Player, character: Model)
+	-- Give spawn protection ForceField
+	giveForceField(character)
+	
+	-- Mark as in safe zone initially (spawn is assumed safe)
+	player:SetAttribute("InSafeZone", true)
+	character:SetAttribute("InSafeZone", true)
+	
+	-- After ForceField expires, rely on zone-based checking
+	task.delay(FORCEFIELD_DURATION + 0.5, function()
+		if character and character.Parent then
+			local root = character:FindFirstChild("HumanoidRootPart")
+			if root then
+				local inZone = isInsideSafeZone(root.Position)
+				player:SetAttribute("InSafeZone", inZone)
+				character:SetAttribute("InSafeZone", inZone)
+			end
+		end
+	end)
+end
+
+local function onPlayerAdded(player: Player)
+	if player.Character then
+		onCharacterAdded(player, player.Character)
+	end
+	player.CharacterAdded:Connect(function(char)
+		onCharacterAdded(player, char)
+	end)
+end
+
+----- Service Lifecycle -----
+
+function SpawnProtectionService:KnitStart()
+	-- Collect safe zone parts
+	collectSafeZoneParts()
+
+	-- Watch for new safe zone parts
+	CS:GetInstanceAddedSignal("SafeZone"):Connect(function(instance)
+		if instance:IsA("BasePart") then
+			table.insert(safeZoneParts, instance)
+		end
+	end)
+
+	-- Setup existing players
+	for _, plr in ipairs(Players:GetPlayers()) do
+		onPlayerAdded(plr)
+	end
+	Players.PlayerAdded:Connect(onPlayerAdded)
+
+	-- Periodic safe zone check (every 1s)
+	task.spawn(function()
+		while true do
+			task.wait(SAFE_ZONE_CHECK_INTERVAL)
+			updateSafeZoneStatus()
+		end
+	end)
+
+	print("[SpawnProtection] Service started - ForceField duration:", FORCEFIELD_DURATION, "s")
+end
+
+function SpawnProtectionService:KnitInit()
+	-- No-op, setup happens in KnitStart
+end
+
+----- Public API -----
+
+-- Check if a player or character is currently protected
+function SpawnProtectionService:IsProtected(playerOrCharacter: Instance): boolean
+	-- Check ForceField first
+	local char: Model
+	if playerOrCharacter:IsA("Player") then
+		char = playerOrCharacter.Character
+	else
+		char = playerOrCharacter
+	end
+	
+	if char and char:FindFirstChildOfClass("ForceField") then
+		return true
+	end
+	
+	-- Check SafeZone attribute
+	if playerOrCharacter:GetAttribute("InSafeZone") then
+		return true
+	end
+	
+	return false
+end
+
+return SpawnProtectionService

--- a/docs/STUDIO_TASKS_SPRINT1.md
+++ b/docs/STUDIO_TASKS_SPRINT1.md
@@ -1,0 +1,53 @@
+# Sprint 1 - Studio Setup Tasks
+
+These tasks require Roblox Studio and cannot be done via code alone.
+Complete these after merging the sprint-1 branch.
+
+## REQUIRED for SafeZone to work
+
+### 1. Create SafeZone Part at spawn
+- In workspace, create a **Part** covering the entire spawn/hub area
+- Name it `SafeZone`
+- Properties:
+  - Anchored = true
+  - CanCollide = false
+  - Transparency = 1
+  - Size = large enough to cover spawn + immediate surroundings
+- Tag it `SafeZone` via CollectionService (or the Tag Editor plugin)
+- SpawnProtectionService will detect it automatically
+
+## REQUIRED for enemy spawn fix
+
+### 2. Move enemy spawn points away from starter area
+- In workspace, find enemy NPCs near the spawn/hub area
+- Move their spawn positions or patrol paths at least 100 studs from spawn
+- Alternatively, add a `SafeZone` check to NPCAI.lua so enemies don't aggro
+  players inside the safe zone (future sprint can handle this in code)
+
+## RECOMMENDED for tutorial text
+
+### 3. Increase dialogue text size
+- In StarterGui > DialogueGui > BaseFrame > Container > DialogueFrame > Speech
+- Increase TextSize from current value to at least 18-20
+- Consider enabling TextScaled = true with a MaxTextSize constraint
+- Also check Narrator label text size
+
+## RECOMMENDED for loading screen
+
+### 4. Loading screen camera
+- Currently shows a static background image
+- Replace with a ViewportFrame showing the game world, or
+- Add a simple camera flyover script in LoadingGui.lua (Sprint 4 task)
+
+## TESTING CHECKLIST
+
+After merging and completing studio tasks:
+
+- [ ] New player spawns with blue ForceField for ~8 seconds
+- [ ] Another player cannot damage you while ForceField is active
+- [ ] Another player cannot damage you while standing in SafeZone part
+- [ ] You CAN still attack NPCs while in SafeZone (PvE allowed)
+- [ ] Tutorial NPC dialogue does NOT close when you walk slightly
+- [ ] Tutorial dialogue buttons still work correctly
+- [ ] ForceField disappears after 8 seconds
+- [ ] After leaving SafeZone, PvP works normally


### PR DESCRIPTION
## Sprint 1: First-Session Survival

Addresses the top churn drivers from Issue #2 (P0-critical onboarding blockers).

### Changes

**fix: Tutorial dialogue no longer cancels on player movement**
- `TutorialGuider.lua` - Removed the `PromptHidden` handler that force-closed active dialogue after 0.6s when the player moved slightly out of proximity range
- Replaced `_G.Talking` with module-local variable to prevent state leaking

**feat: Spawn protection system**
- New `SpawnProtectionService.lua` - Gives 8s ForceField on spawn, manages SafeZone attribute
- Players and characters get `InSafeZone` attribute set by periodic zone checking
- Duration configurable via `Costs.SpawnProtectionDuration`

**fix: PvP disabled in safe zones**
- `Fist_S.lua` - Added `isPvPBlocked()` check before applying melee damage
- `DamageModule.lua` - Added same check covering all bending abilities
- PvE (attacking NPCs) is unaffected in all cases

### Studio Setup Required

See `docs/STUDIO_TASKS_SPRINT1.md` for workspace changes:
1. Create SafeZone Part covering spawn area (required)
2. Move enemy spawns away from starter area (required)
3. Increase dialogue text size (recommended)

### Testing

- [ ] New spawn gets 8s ForceField
- [ ] PvP blocked in SafeZone
- [ ] PvE still works in SafeZone
- [ ] Tutorial dialogue persists when walking
- [ ] Dialogue buttons still function correctly

Closes part of #2
Related: #10 (master tracker)