### PR TITLE
feat: Sprint 1 - First-Session Survival

### DIFF
--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/AirBending/AirKick/RemoteEvent/AirKick_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/AirBending/AirKick/RemoteEvent/AirKick_S.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: Script
+local Players = game:GetService("Players")
 script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local OnHit = false
 	local Alive = true
@@ -79,6 +80,9 @@ wait(0.2)
 				misc.UpKnockback(hit.Parent.HumanoidRootPart, 35, 65, 0.15, h)
 				Hits[hit.Parent.Name] = true
 				local Damage = math.random(15,23)
+				-- SafeZone: block PvP if either player is in safe zone
+				local victimPlayer = Players:GetPlayerFromCharacter(hit.Parent)
+				if victimPlayer and (plr.Character:GetAttribute("InSafeZone") or hit.Parent:GetAttribute("InSafeZone")) then return end
 				hit.Parent.Humanoid:TakeDamage(Damage)
 			
 		

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/EarthBending/EarthStomp/RemoteEvent/EarthStomp_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/EarthBending/EarthStomp/RemoteEvent/EarthStomp_S.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: Script
+local Players = game:GetService("Players")
 script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local OnHit = false
 	local Alive = true
@@ -103,6 +104,9 @@ end)
 
 				Hits[hit.Parent.Name] = true
 				local Damage = math.random(15,23)
+				-- SafeZone: block PvP if either player is in safe zone
+				local victimPlayer = Players:GetPlayerFromCharacter(hit.Parent)
+				if victimPlayer and (plr.Character:GetAttribute("InSafeZone") or hit.Parent:GetAttribute("InSafeZone")) then return end
 				hit.Parent.Humanoid:TakeDamage(Damage)
 				
 			

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/FireBending/FireDropKick/RemoteEvent/FireDropKick_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/FireBending/FireDropKick/RemoteEvent/FireDropKick_S.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: Script
+local Players = game:GetService("Players")
 script.Parent.OnServerEvent:Connect(function(plr,direction,mouseaim)
 	local OnHit = false
 	local Alive = true
@@ -127,6 +128,9 @@ local TS = game:GetService("TweenService")
 				misc.UpKnockback(hit.Parent.HumanoidRootPart, 35, 41, 0.15, h)
 				Hits[hit.Parent.Name] = true
 				local Damage = math.random(15,23)
+				-- SafeZone: block PvP if either player is in safe zone
+				local victimPlayer = Players:GetPlayerFromCharacter(hit.Parent)
+				if victimPlayer and (plr.Character:GetAttribute("InSafeZone") or hit.Parent:GetAttribute("InSafeZone")) then return end
 				hit.Parent.Humanoid:TakeDamage(Damage)
 				local ef = game.ReplicatedStorage.FX.Fire.Fire:Clone()
 				ef.Parent = hit.Parent:FindFirstChild("UpperTorso")

--- a/ReplicatedStorage/Assets/Models/Combat/Bendings/Fist/Fist/Fist_S.lua
+++ b/ReplicatedStorage/Assets/Models/Combat/Bendings/Fist/Fist/Fist_S.lua
@@ -133,6 +133,9 @@ attackRemote.OnServerEvent:Connect(function(Player, Action, isHoldingSpace)
 											end
 											
 										else
+											-- SafeZone: block PvP damage if either player is in safe zone
+											local blockPvP = isPlayer and (Character:GetAttribute("InSafeZone") or v.Parent:GetAttribute("InSafeZone"))
+											if blockPvP then return end
 											local eHum = v.Parent.Humanoid
 
 											Player.CombatStats:FindFirstChild("EXP").Value = 	Player.CombatStats:FindFirstChild("EXP").Value +5

--- a/ReplicatedStorage/Modules/Custom/QuestsModule/Conversation.lua
+++ b/ReplicatedStorage/Modules/Custom/QuestsModule/Conversation.lua
@@ -55,36 +55,74 @@ return{
 			}
 		},
 		[3] = {
-			-- Quest 
-			Title = "Now that you've mastered the basics, let's teach you how to unlock your first ability",
+			-- Quest: Post-combat teaching - Block, Sprint, Meditation, then progression
+			Title = "Great work defeating those enemies! Before you move on, let me teach you some survival skills.",
 			Objective = QuestsModule.QuestObjectives.Kill,
 			Options = {
 				[1] = {
-					Text = "Continue",
+					Text = "I'm ready to learn!",
 					Image = "rbxassetid://17575066019",
 					ClickAction = {
 						Dialogue = {
-							Title = "Complete quests to earn XP and unlock your skills!! XP will Level you up which will make you stronger and able to fight more higher level enemies",
+							Title = "Blocking: Press Q to block enemy attacks. Blocking reduces incoming damage significantly. Time it right for a Perfect Block to stun your attacker!",
 							Options = {
 								[1] = {
-									Text = "Continue",
+									Text = "Got it!",
 									Image = "rbxassetid://17575066019",
 									ClickAction = {
 										Dialogue = {
-											Title = "Completing Quests, will also give you Gold in order to buy objects that allow you travel around RoVatar!",
+											Title = "Sprinting: Hold Left Shift to run faster. Sprinting uses stamina, so keep an eye on your stamina bar. You can't sprint and block at the same time.",
 											Options = {
 												[1] = {
-													Text = "Okay",
+													Text = "Continue",
 													Image = "rbxassetid://17575066019",
 													ClickAction = {
 														Dialogue = {
-															Title = "So lets get you to the Rock Tribe to begin your training in unlocking your first ability! Come find me there",
+															Title = "Meditation: When your stamina runs low, press N to sit and meditate. This will restore your stamina quickly. Find a safe spot before meditating - you can't move or fight while recovering!",
 															Options = {
 																[1] = {
-																	Text = "Teleport Me",
+																	Text = "Continue",
 																	Image = "rbxassetid://17575066019",
 																	ClickAction = {
-																		Teleport = Constant.Places.RoVatar.PlaceId,
+																		Dialogue = {
+																			Title = "Now about growing stronger - complete quests to earn XP and unlock your skills! XP will Level you up which will make you stronger and able to fight higher level enemies.",
+																			Options = {
+																				[1] = {
+																					Text = "Continue",
+																					Image = "rbxassetid://17575066019",
+																					ClickAction = {
+																						Dialogue = {
+																							Title = "Completing Quests will also give you Gold in order to buy objects that allow you to travel around RoVatar!",
+																							Options = {
+																								[1] = {
+																									Text = "Okay",
+																									Image = "rbxassetid://17575066019",
+																									ClickAction = {
+																										Dialogue = {
+																											Title = "So let's get you to the Rock Tribe to begin your training in unlocking your first ability! Come find me there.",
+																											Options = {
+																												[1] = {
+																													Text = "Teleport Me",
+																													Image = "rbxassetid://17575066019",
+																													ClickAction = {
+																														Teleport = Constant.Places.RoVatar.PlaceId,
+																													}
+																												},
+																												[2] = {
+																													Text = "Let me explore first",
+																													Image = "rbxassetid://17575582976",
+																													ClickAction = {} -- Exit
+																												}
+																											},
+																										},
+																									}
+																								}
+																							},
+																						},
+																					}
+																				}
+																			},
+																		},
 																	}
 																}
 															},

--- a/ReplicatedStorage/Modules/Custom/SafeZoneUtils.lua
+++ b/ReplicatedStorage/Modules/Custom/SafeZoneUtils.lua
@@ -1,0 +1,91 @@
+-- @ScriptType: ModuleScript
+-- SafeZoneUtils: Prevents PVP damage in designated safe zones
+-- Sprint 1 - First-Session Survival
+-- 
+-- HOW IT WORKS:
+-- 1. SafeZoneEnforcer (server script) monitors player positions
+-- 2. When a player enters a SafeZone, sets character attribute "InSafeZone" = true
+-- 3. Combat scripts check for this attribute before applying PvP damage
+-- 4. NPC/PvE damage is unaffected
+--
+-- STUDIO SETUP REQUIRED:
+-- 1. Create a Part in Workspace named "SafeZone" around the spawn area
+-- 2. Set Anchored = true, CanCollide = false, Transparency = 0.8
+-- 3. Add CollectionService tag "SafeZone" to the part
+-- 4. Size it to cover the spawn area (e.g. 100x50x100 studs)
+
+local CollectionService = game:GetService("CollectionService")
+local Players = game:GetService("Players")
+
+local SafeZoneUtils = {}
+
+-- Cache safe zone parts
+local safeZoneParts = {}
+
+local function refreshSafeZones()
+	safeZoneParts = CollectionService:GetTagged("SafeZone")
+end
+
+CollectionService:GetInstanceAddedSignal("SafeZone"):Connect(refreshSafeZones)
+CollectionService:GetInstanceRemovedSignal("SafeZone"):Connect(refreshSafeZones)
+refreshSafeZones()
+
+-- Check if a position is inside any SafeZone part
+function SafeZoneUtils.IsPositionInSafeZone(position: Vector3): boolean
+	for _, zonePart in ipairs(safeZoneParts) do
+		if zonePart and zonePart:IsA("BasePart") then
+			local relativePos = zonePart.CFrame:PointToObjectSpace(position)
+			local halfSize = zonePart.Size / 2
+			if math.abs(relativePos.X) <= halfSize.X
+				and math.abs(relativePos.Y) <= halfSize.Y
+				and math.abs(relativePos.Z) <= halfSize.Z then
+				return true
+			end
+		end
+	end
+	return false
+end
+
+-- Check if a character is in a safe zone (uses cached attribute for performance)
+function SafeZoneUtils.IsInSafeZone(character: Model): boolean
+	if not character then return false end
+	return character:GetAttribute("InSafeZone") == true
+end
+
+-- Should PvP damage be blocked? Returns true to PREVENT damage
+-- Only blocks player-vs-player. PvE is always allowed.
+function SafeZoneUtils.ShouldBlockPvPDamage(attackerChar: Model, victimChar: Model): boolean
+	if not attackerChar or not victimChar then return false end
+	
+	-- Only block if both are players
+	local attackerPlayer = Players:GetPlayerFromCharacter(attackerChar)
+	local victimPlayer = Players:GetPlayerFromCharacter(victimChar)
+	if not attackerPlayer or not victimPlayer then return false end
+	
+	-- Block if either is in safe zone
+	return SafeZoneUtils.IsInSafeZone(attackerChar) or SafeZoneUtils.IsInSafeZone(victimChar)
+end
+
+-- Server-side: Start monitoring all players for safe zone entry/exit
+-- Call this once from a server script
+function SafeZoneUtils.StartEnforcement()
+	local CHECK_INTERVAL = 0.5 -- seconds between position checks
+	
+	task.spawn(function()
+		while true do
+			for _, player in ipairs(Players:GetPlayers()) do
+				local char = player.Character
+				if char then
+					local hrp = char:FindFirstChild("HumanoidRootPart")
+					if hrp then
+						local inZone = SafeZoneUtils.IsPositionInSafeZone(hrp.Position)
+						char:SetAttribute("InSafeZone", inZone)
+					end
+				end
+			end
+			task.wait(CHECK_INTERVAL)
+		end
+	end)
+end
+
+return SafeZoneUtils

--- a/ReplicatedStorage/Modules/Custom/VFXHandler/Boomerang.lua
+++ b/ReplicatedStorage/Modules/Custom/VFXHandler/Boomerang.lua
@@ -3,6 +3,7 @@
 local Tween = game:GetService("TweenService")
 local RS = game:GetService("ReplicatedStorage")
 local CS = game:GetService("CollectionService")
+local Players = game:GetService("Players")
 
 local Modules = RS.Modules
 local misc = require(Modules.Packages.Misc)
@@ -107,6 +108,9 @@ return function(plr, direction, mouseaim)
 				end
 				
 				local Damage = math.random(BoomerangDamageRange.X, BoomerangDamageRange.Y)
+				-- SafeZone: block PvP if either player is in safe zone
+				local victimPlayer = Players:GetPlayerFromCharacter(hit.Parent)
+				if victimPlayer and (plr.Character:GetAttribute("InSafeZone") or hit.Parent:GetAttribute("InSafeZone")) then return end
 				hum:TakeDamage(Damage)
 				
 				local color1 = Color3.fromRGB(187, 0, 5)

--- a/ReplicatedStorage/Modules/Custom/VFXHandler/MeteoriteSword.lua
+++ b/ReplicatedStorage/Modules/Custom/VFXHandler/MeteoriteSword.lua
@@ -147,6 +147,9 @@ return function(Player, Action, isHoldingSpace)
 												Exp.Value += MeteoriteSwordXP
 											end
 
+											-- SafeZone: block PvP if either player is in safe zone
+											local blockPvP = isPlayer and (Character:GetAttribute("InSafeZone") or v.Parent:GetAttribute("InSafeZone"))
+											if blockPvP then return end
 											eHum:TakeDamage(M1Damage)
 
 											local LastDamage = eHum.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', eHum.Parent)

--- a/ReplicatedStorage/Modules/Custom/VFXHandler/WaterStance.lua
+++ b/ReplicatedStorage/Modules/Custom/VFXHandler/WaterStance.lua
@@ -4,6 +4,7 @@ local Tween = game:GetService("TweenService")
 local RS = game:GetService("ReplicatedStorage")
 local CS = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
+local Players = game:GetService("Players")
 
 local Modules = RS.Modules
 local misc = require(Modules.Packages.Misc)
@@ -171,6 +172,9 @@ return function(plr, typ, direction, mouseaim)
 						misc.UpKnockback(hrp2, 35, 65, 0.15, _hitBox)
 
 						local Damage = math.random(WaterStanceDamageRange.X, WaterStanceDamageRange.Y)
+						-- SafeZone: block PvP if either player is in safe zone
+						local victimPlayer = Players:GetPlayerFromCharacter(eChar)
+						if victimPlayer and (char:GetAttribute("InSafeZone") or eChar:GetAttribute("InSafeZone")) then return end
 						hum2:TakeDamage(Damage)
 
 						local LastDamage = hum2.Parent:FindFirstChild("DamageBy") or Instance.new('ObjectValue', hum2.Parent)

--- a/ServerScriptService/Server/Services/World/SafeZoneEnforcer.lua
+++ b/ServerScriptService/Server/Services/World/SafeZoneEnforcer.lua
@@ -1,0 +1,12 @@
+-- @ScriptType: Script
+-- SafeZoneEnforcer: Server script that monitors player positions and sets InSafeZone attribute
+-- Location: ServerScriptService/Server/Services/World/SafeZoneEnforcer.lua
+-- Sprint 1 - First-Session Survival
+
+local RS = game:GetService("ReplicatedStorage")
+local SafeZoneUtils = require(RS.Modules.Custom.SafeZoneUtils)
+
+-- Start monitoring all player positions for SafeZone entry/exit
+SafeZoneUtils.StartEnforcement()
+
+print("[SafeZoneEnforcer] Started - PvP disabled in SafeZone areas")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/DialogueGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/DialogueGui.lua
@@ -147,6 +147,14 @@ function DialogueGui:InitButtons()
 	ui.DialogueFrame.ContinueButton.Activated:Connect(function()
 		ContinueButton(self)
 	end)
+	
+	-- Click anywhere on the dialogue area to advance (not just the small continue button)
+	-- This fixes the issue where clicking outside the continue button cancels dialogue
+	ui.BaseFrame.Activated:Connect(function()
+		if self.InProcess then
+			ContinueButton(self)
+		end
+	end)
 end
 
 -- Show the dialogue based on the provided data
@@ -167,6 +175,23 @@ function DialogueGui:ShowDialogue(data : CT.DialogueDataType)
 
 	self:UpdateTxts(self._Data)
 	self:UpdateOptions()
+end
+
+-- Skip all remaining dialogue and close - used by tutorial skip button
+function DialogueGui:SkipAll()
+	if self.SpeechThread then
+		local status = coroutine.status(self.SpeechThread)
+		if status ~= "dead" then
+			coroutine.close(self.SpeechThread)
+		end
+	end
+	
+	if self._Data and self._Data.OnSkip then
+		self._Data.OnSkip()
+	end
+	
+	self:Toggle(false)
+	self.InProcess = false
 end
 
 -- Update the text elements in the dialogue

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/NPC/TutorialGuider.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/NPC/TutorialGuider.lua
@@ -157,6 +157,9 @@ end
 function TutorialGuider:StartConversation()
 	local plrQuestData :CustomTypes.PlayerQuestDataModel = _G.QuestsData
 	
+	-- Hide non-essential UI during tutorial for cleaner experience
+	self:ToggleTutorialUI(false)
+	
 	local questData = plrQuestData.TutorialQuestData
 	if questData.Id then
 		if questData.IsCompleted then
@@ -167,6 +170,24 @@ function TutorialGuider:StartConversation()
 	else
 		-- Assign 
 		CreateDialogue(self, Conversation.Tutorial[2])
+	end
+end
+
+-- Hide/show non-essential UI during tutorial to reduce clutter
+function TutorialGuider:ToggleTutorialUI(show: boolean)
+	-- These screens are hidden during tutorial to avoid overwhelming new players
+	local screensToHide = {
+		Constants.UiScreenTags.ShopGui,
+		Constants.UiScreenTags.BackPackGui,
+		Constants.UiScreenTags.MapGui,
+		Constants.UiScreenTags.GamePassGui,
+		Constants.UiScreenTags.StoreGui,
+	}
+	
+	for _, screenTag in ipairs(screensToHide) do
+		pcall(function()
+			UIController:ToggleScreen(screenTag, show)
+		end)
 	end
 end
 
@@ -214,13 +235,17 @@ function TutorialGuider:SetupPrompt()
 			self.Humanoid.WalkSpeed = 10
 			self.Prompt.Enabled = false
 			
-			--Karna Stop Dialogue
+			-- Restore UI when player walks away from tutorial NPC
+			self:ToggleTutorialUI(true)
 		end
 		
 		if Talking then
 			Talking = false
 			task.wait(.6)
 			DialogueGui:Finish(true)
+			
+			-- Restore UI when dialogue is force-closed
+			self:ToggleTutorialUI(true)
 		end
 	end)
 	

--- a/StarterPlayer/StarterPlayerScripts/Game/Controllers/Character/CharacterController.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Controllers/Character/CharacterController.lua
@@ -1459,60 +1459,156 @@ local Container = {
 	-----* AirBending
 	[CustomControls.AirBending.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:AirBending(true)		
+			-- Single-keypress: select ability and immediately start activation
+			if _G.SelectedCombat ~= AirBending then
+				-- Deactivate any current ability first
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				ToggleBoomerang(false)
+				ToggleSword(false)
+				if CF.PlayerData.DoesPlayerHaveAbility(_G.PlayerData, Constants.GameInventory.Abilities.AirBending.Id) then
+					_G.SelectedCombat = AirBending
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Abilities.AirBending.Id)
+				else
+					return
+				end
+			end
+			-- Activate the ability
+			AirBending(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:AirBending(false)
+			-- Fire the ability on key release
+			if _G.SelectedCombat == AirBending then
+				AirBending(false)
+			end
 		end,
 	},
 
 	-----* WaterBending
 	[CustomControls.WaterBending.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:WaterBending(true)
+			if _G.SelectedCombat ~= WaterBending then
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				ToggleBoomerang(false)
+				ToggleSword(false)
+				if CF.PlayerData.DoesPlayerHaveAbility(_G.PlayerData, Constants.GameInventory.Abilities.WaterBending.Id) then
+					_G.SelectedCombat = WaterBending
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Abilities.WaterBending.Id)
+				else
+					return
+				end
+			end
+			WaterBending(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:WaterBending(false)
+			if _G.SelectedCombat == WaterBending then
+				WaterBending(false)
+			end
 		end,
 	},
 
 	-----* FireBending
 	[CustomControls.FireBending.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:FireBending(true)
+			if _G.SelectedCombat ~= FireBending then
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				ToggleBoomerang(false)
+				ToggleSword(false)
+				if CF.PlayerData.DoesPlayerHaveAbility(_G.PlayerData, Constants.GameInventory.Abilities.FireBending.Id) then
+					_G.SelectedCombat = FireBending
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Abilities.FireBending.Id)
+				else
+					return
+				end
+			end
+			FireBending(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:FireBending(false)
+			if _G.SelectedCombat == FireBending then
+				FireBending(false)
+			end
 		end,
 	},
 
 	-----* EarthBending
 	[CustomControls.EarthBending.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:EarthBending(true)
+			if _G.SelectedCombat ~= EarthBending then
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				ToggleBoomerang(false)
+				ToggleSword(false)
+				if CF.PlayerData.DoesPlayerHaveAbility(_G.PlayerData, Constants.GameInventory.Abilities.EarthBending.Id) then
+					_G.SelectedCombat = EarthBending
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Abilities.EarthBending.Id)
+				else
+					return
+				end
+			end
+			EarthBending(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:EarthBending(false)
+			if _G.SelectedCombat == EarthBending then
+				EarthBending(false)
+			end
 		end,
 	},
 
 	-----* Boomerang
 	[CustomControls.Boomerang.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:Boomerang(true)
+			if _G.SelectedCombat ~= Boomerang then
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				local passesData = _G.PlayerData.GamePurchases.Passes
+				if passesData[Constants.IAPItems.Boomerang.Id] then
+					ToggleSword(false)
+					_G.SelectedCombat = Boomerang
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Weapons.Boomerang)
+					ToggleBoomerang(true)
+				else
+					return
+				end
+			end
+			Boomerang(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:Boomerang(false)
+			if _G.SelectedCombat == Boomerang then
+				Boomerang(false)
+			end
 		end,
 	},
 
 	-----* MeteoriteSword
 	[CustomControls.MeteoriteSword.actionName] = {
 		[Enum.UserInputState.Begin] = function(inputObject :InputObject, button :ImageButton)
-			--CharacterController:MeteoriteSword(true)
+			if _G.SelectedCombat ~= MeteoriteSword then
+				if _G.SelectedCombat and _G.ActiveBending ~= "None" then
+					_G.SelectedCombat(false)
+				end
+				local passesData = _G.PlayerData.GamePurchases.Passes
+				if passesData[Constants.IAPItems.MeteoriteSword.Id] then
+					ToggleBoomerang(false)
+					_G.SelectedCombat = MeteoriteSword
+					PlayerMenuGui:ToggleSelection(true, Constants.GameInventory.Weapons.MeteoriteSword)
+					ToggleSword(true)
+				else
+					return
+				end
+			end
+			MeteoriteSword(true)
 		end,
 		[Enum.UserInputState.End] = function(inputObject :InputObject, button :ImageButton)
-			CharacterController:MeteoriteSword(false)
+			if _G.SelectedCombat == MeteoriteSword then
+				MeteoriteSword(false)
+			end
 		end,
 	}
 


### PR DESCRIPTION
## Sprint 1: First-Session Survival

**Goal**: New player completes tutorial and enters main game in <3 minutes, zero confusion, no griefing.

### Code Changes (13 files, this PR)

**Task 1 - Dialogue click-anywhere-to-advance** (DialogueGui.lua)
- BaseFrame click handler advances dialogue (not just the small ContinueButton)
- New SkipAll() method for tutorial skip support

**Task 3+10 - Tutorial teaches survival skills** (Conversation.lua)
- Tutorial[3] restructured: teaches Block (Q), Sprint (Shift), Meditation (N) before progression
- Added escape option ("Let me explore first") at teleport step

**Task 4 - SafeZone PvP protection** (SafeZoneUtils.lua, SafeZoneEnforcer.lua + 7 combat scripts)
- New SafeZoneUtils module with position-based zone detection
- SafeZoneEnforcer server script monitors player positions every 0.5s
- Sets InSafeZone character attribute used by combat scripts
- PvP blocked in: Fist_S, AirKick_S, EarthStomp_S, FireDropKick_S, WaterStance, Boomerang, MeteoriteSword
- PvE (player vs NPC) is always allowed

**Task 6 - Single-keypress ability activation** (CharacterController.lua)
- All 6 ability keybinds (1-4 elements + 5 boomerang + 6 sword) now select AND activate in one press
- Eliminates the confusing 2-step: press number to select, then click to use
- Key press = select + start; key release = fire ability

**Task 7 - Hide UI during tutorial** (TutorialGuider.lua)
- Hides Shop, Backpack, Map, GamePass, Store during tutorial dialogue
- Restores all UI when player walks away or dialogue closes

### Studio Tasks (manual, not in this PR)

These require Roblox Studio as they involve workspace objects, not code:

- [ ] **SafeZone Part**: Create anchored Part in Workspace around spawn (100x50x100 studs), CanCollide=false, Transparency=0.8, add CollectionService tag "SafeZone"
- [ ] **Move NPC spawners**: Relocate enemy spawn points away from player spawn area
- [ ] **Tutorial text sizing**: Set TextScaled=true on dialogue TextLabels to prevent overflow
- [ ] **Controls Guide**: Update ControlsGuideGui images/labels with correct key mappings (Q=Block, Shift=Sprint, N=Meditate, 1-4=Elements, 5=Boomerang, 6=Sword)
- [ ] **Teleport loading screen**: Review TeleportGui for second loading screen issue

### Testing Notes

1. SafeZone requires Studio part to be placed - without it, PvP works normally everywhere
2. Single-keypress activation changes combat flow significantly - test all 6 abilities
3. Tutorial dialogue restructure adds ~4 extra dialogue screens (Block/Sprint/Meditation teaching)
4. UI hiding during tutorial uses pcall so failures don't break dialogue flow