### PR TITLE
refactor: flatten 10 GUI components from depth 7 to depth 6

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/BendingSelectionGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/BendingSelectionGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/BendingSelectionGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/ControlsGuideGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/ControlsGuideGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/ControlsGuideGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/CustomizationUI.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/CustomizationUI.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/LoadGameGui/CustomizationUI.lua (cleanup sprint)
 local RS = game:GetService("ReplicatedStorage")
 local MPS = game:GetService("MarketplaceService")
 

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/GamePassGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/GamePassGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/GamePassGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/MainMenuGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/MainMenuGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/MainMenuGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/MapGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/MapGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/MapGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/QuestGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/QuestGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/QuestGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/SettingsGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/SettingsGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/SettingsGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/ShopGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/ShopGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/ShopGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")

--- a/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/StoreGui.lua
+++ b/StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/StoreGui.lua
@@ -1,4 +1,5 @@
 -- @ScriptType: ModuleScript
+-- Moved from: Components/GUIs/HomeScreens/StoreGui.lua (cleanup sprint)
 local CollectionService = game:GetService("CollectionService")
 local Debris = game:GetService("Debris")
 local RS = game:GetService("ReplicatedStorage")


### PR DESCRIPTION
## Summary
- Moved 9 Knit Component GUIs from `GUIs/HomeScreens/` up to `GUIs/`, eliminating the `HomeScreens/` folder
- Moved `CustomizationUI.lua` from `GUIs/LoadGameGui/` up to `GUIs/`, eliminating an empty subfolder
- All 10 files are Knit Components (auto-discovered by CollectionService tag) — zero `require()` callers, zero code changes needed beyond the move

## What changed
All files moved from depth 7 to depth 6 within `StarterPlayer/StarterPlayerScripts/Game/Components/GUIs/`:
- `HomeScreens/BendingSelectionGui.lua` → `BendingSelectionGui.lua`
- `HomeScreens/ControlsGuideGui.lua` → `ControlsGuideGui.lua`
- `HomeScreens/GamePassGui.lua` → `GamePassGui.lua`
- `HomeScreens/MainMenuGui.lua` → `MainMenuGui.lua`
- `HomeScreens/MapGui.lua` → `MapGui.lua`
- `HomeScreens/QuestGui.lua` → `QuestGui.lua`
- `HomeScreens/SettingsGui.lua` → `SettingsGui.lua`
- `HomeScreens/ShopGui.lua` → `ShopGui.lua`
- `HomeScreens/StoreGui.lua` → `StoreGui.lua`
- `LoadGameGui/CustomizationUI.lua` → `CustomizationUI.lua`

## Verification
- Grep confirms zero `require()` references to old paths (`HomeScreens/`, `LoadGameGui/CustomizationUI`)
- No name collisions with existing files in `GUIs/`
- No Rojo project config references to moved paths

## Test plan
- [ ] Rojo sync and verify all 10 GUI components load in Studio
- [ ] Open each screen in-game to confirm tag-based discovery still works
- [ ] Confirm no errors in output console related to missing modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)